### PR TITLE
Add glassmorphism background to calculator

### DIFF
--- a/plans/glassmorphism-background.md
+++ b/plans/glassmorphism-background.md
@@ -1,0 +1,59 @@
+# Plan: Glassmorphism Background
+
+## Goal
+
+Replace the flat `#1a1a2e` body background with a glassmorphism design: a vibrant gradient backdrop with floating color blobs, and a frosted-glass calculator card.
+
+## File to Change
+
+`public/style.css` — all changes are CSS-only; no HTML or JS changes needed.
+
+## Changes
+
+### 1. Body background — vibrant gradient + color blobs
+
+Replace the current flat `background: #1a1a2e` with:
+
+- A dark base gradient (`#0f0c29` → `#302b63` → `#24243e`, diagonal).
+- Two pseudo-element color blobs (via `body::before` and `body::after`) — one warm (pink/purple), one cool (teal/blue) — that sit behind the calculator and create the "colored light" effect glassmorphism relies on.
+- Blobs are large (`300–400px`), blurred (`blur(100px)`), positioned off-center, `border-radius: 50%`, low opacity, and `z-index: -1`.
+- Add `overflow: hidden` on body to prevent blobs from causing scrollbars.
+
+### 2. Calculator card — frosted glass
+
+Update `.calculator` to:
+
+- `background: rgba(255, 255, 255, 0.05)` — near-transparent white tint.
+- `backdrop-filter: blur(20px)` and `-webkit-backdrop-filter: blur(20px)` for Safari.
+- `border: 1px solid rgba(255, 255, 255, 0.1)` — subtle light border for the glass edge.
+- Keep existing `border-radius: 16px`, `padding`, `width`, and `box-shadow`.
+
+### 3. Display area — subtle glass effect
+
+Update `.display` to:
+
+- `background: rgba(15, 52, 96, 0.4)` (same hue as current `#0f3460` but semi-transparent).
+- `backdrop-filter: blur(10px)`.
+- `border: 1px solid rgba(255, 255, 255, 0.05)`.
+
+### 4. Digit buttons — glass tint
+
+Update `button` (default digit buttons) to:
+
+- `background: rgba(255, 255, 255, 0.05)`.
+- Hover: `background: rgba(255, 255, 255, 0.1)`.
+- Keep operator/equals/clear button colors unchanged (they're accent colors).
+
+## What NOT to change
+
+- HTML structure — no new elements needed (blobs use pseudo-elements).
+- JavaScript — no logic changes.
+- Operator, equals, and clear button colors — keep the existing red/green accents.
+- Typography, sizing, spacing — keep as-is.
+
+## Acceptance Criteria
+
+- Page has a visible multi-color gradient with soft color blobs behind the calculator.
+- Calculator card has a frosted-glass look (semi-transparent, blurred backdrop).
+- All buttons remain readable and functional.
+- No horizontal scrollbar from blobs.

--- a/public/style.css
+++ b/public/style.css
@@ -9,12 +9,43 @@ body {
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background: #1a1a2e;
+  background: linear-gradient(135deg, #0f0c29, #302b63, #24243e);
   font-family: 'Segoe UI', system-ui, sans-serif;
+  position: relative;
+  overflow: hidden;
+}
+
+body::before,
+body::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  z-index: -1;
+}
+
+body::before {
+  width: 400px;
+  height: 400px;
+  background: rgba(233, 69, 96, 0.35);
+  top: -80px;
+  left: -100px;
+  filter: blur(100px);
+}
+
+body::after {
+  width: 350px;
+  height: 350px;
+  background: rgba(12, 202, 74, 0.25);
+  bottom: -60px;
+  right: -80px;
+  filter: blur(100px);
 }
 
 .calculator {
-  background: #16213e;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
   padding: 24px;
   width: 320px;
@@ -22,7 +53,10 @@ body {
 }
 
 .display {
-  background: #0f3460;
+  background: rgba(15, 52, 96, 0.4);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 12px;
   padding: 16px 20px;
   margin-bottom: 20px;
@@ -64,14 +98,14 @@ button {
   border: none;
   border-radius: 12px;
   cursor: pointer;
-  background: #1a1a3e;
+  background: rgba(255, 255, 255, 0.05);
   color: #e0e0e0;
   transition: background 0.15s, transform 0.1s;
   font-family: inherit;
 }
 
 button:hover {
-  background: #2a2a5e;
+  background: rgba(255, 255, 255, 0.1);
 }
 
 button:active {


### PR DESCRIPTION
## Summary
- Replaced flat background with vibrant diagonal gradient and floating color blobs (pseudo-elements)
- Applied frosted-glass effect to calculator card using `backdrop-filter: blur(20px)`
- Made display and digit buttons semi-transparent with glass tinting
- CSS-only changes — no HTML or JS modifications

Implements plan: `plans/glassmorphism-background.md`

## Test plan
- [x] Open the calculator in a browser and verify the gradient background with color blobs is visible
- [x] Confirm the calculator card has a frosted-glass appearance
- [x] Verify all buttons remain readable and functional
- [x] Check there is no horizontal scrollbar from the blobs
- [x] Test in Safari (webkit prefix for backdrop-filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)